### PR TITLE
Handle DB problems when creating account

### DIFF
--- a/docker/CMSRucioClient/scripts/syncaccounts.py
+++ b/docker/CMSRucioClient/scripts/syncaccounts.py
@@ -9,7 +9,7 @@ import os
 import re
 
 from rucio.client.client import Client
-from rucio.common.exception import AccountNotFound
+from rucio.common.exception import AccountNotFound, DatabaseException
 
 SYNC_ACCOUNT_FMT = 'sync_%s'
 
@@ -61,13 +61,17 @@ class SyncAccounts(object):
             logging.info('creating account %s. Dry run',
                          account)
         elif missing:
-            self.rcli.add_account(
-                account=account,
-                type='USER',
-                email=None
-            )
-            logging.debug('created account %s',
-                          account)
+            try:
+                self.rcli.add_account(
+                    account=account,
+                    type='USER',
+                    email=None
+                )
+                logging.debug('created account %s',
+                              account)
+            except DatabaseException:
+                logging.warn('Could not create account %s',
+                              account)
 
         return missing
 


### PR DESCRIPTION
This "fixes" the one crash I see. It's probably not a complete fix as the problem is that the account name is too long:

```
Details: (cx_Oracle.DatabaseError) ORA-12899: value too large for column "CMS_RUCIO_TEST"."ACCOUNTS"."ACCOUNT" (actual: 26, maximum: 25) [SQL: u'INSERT INTO accounts (account, account_type, status, 
email, suspended_at, deleted_at, updated_at, created_at) VALUES (:account, :account_type, :status, :email, :suspended_at, :deleted_at, :updated_at, :created_at)'] [parameters: {'status': 'ACTIVE', '
account': 'sync_t3_ch_cern_cta_test_2', 'account_type': 'USER', 'created_at': datetime.datetime(2019, 2, 18, 20, 1, 32, 942714), 'suspended_at': None, 'updated_at': datetime.datetime(2019, 2, 18, 20
, 1, 32, 942701), 'deleted_at': None, 'email': None}] (Background on this error at: http://sqlalche.me/e/4xp6)
```